### PR TITLE
Add dynamic toggle button state for dropdowns

### DIFF
--- a/src/sphinx_dropdown_toggle/static/dropdown_toggle.js
+++ b/src/sphinx_dropdown_toggle/static/dropdown_toggle.js
@@ -10,9 +10,9 @@ document.addEventListener("DOMContentLoaded", () => {
     }
 
     // Function to check current state of all dropdowns
-    function checkDropdownState() {
-        const details = document.querySelectorAll('details.dropdown, details.sd-dropdown, details.toggle-details');
-        const toggleableDivs = document.querySelectorAll('div.dropdown button.toggle-button');
+    function checkDropdownState(article) {
+        const details = article.querySelectorAll('details.dropdown, details.sd-dropdown, details.toggle-details');
+        const toggleableDivs = article.querySelectorAll('div.dropdown button.toggle-button');
         
         let allOpen = true;
         let allClosed = true;

--- a/src/sphinx_dropdown_toggle/static/dropdown_toggle.js
+++ b/src/sphinx_dropdown_toggle/static/dropdown_toggle.js
@@ -130,23 +130,31 @@ document.addEventListener("DOMContentLoaded", () => {
             });
         }
         
-        // Also watch for toggle-button changes
-        const buttons = document.querySelectorAll('button.toggle-button');
-        console.log('Found', buttons.length, 'toggle buttons');
-        if (buttons.length > 0) {
-            const buttonObserver = new MutationObserver((mutations) => {
-                mutations.forEach((mutation) => {
-                    if (mutation.type === 'attributes' && mutation.attributeName === 'class') {
-                        console.log('Toggle button class changed:', mutation.target.className);
-                        updateToggleButton();
-                    }
-                });
+        // Hook into togglebutton click events more directly
+        // Add click listeners to admonition titles and toggle buttons
+        const admonitionTitles = document.querySelectorAll('.admonition-title');
+        const toggleButtons = document.querySelectorAll('button.toggle-button');
+        
+        console.log('Found', admonitionTitles.length, 'admonition titles');
+        console.log('Found', toggleButtons.length, 'toggle buttons');
+        
+        // Listen for clicks on admonition titles (which trigger toggles)
+        admonitionTitles.forEach(title => {
+            title.addEventListener('click', () => {
+                console.log('Admonition title clicked, updating toggle state...');
+                // Use a small delay to let the togglebutton script finish its work
+                setTimeout(updateToggleButton, 10);
             });
-            
-            buttons.forEach(button => {
-                buttonObserver.observe(button, { attributes: true, attributeFilter: ['class'] });
+        });
+        
+        // Listen for clicks on toggle buttons directly
+        toggleButtons.forEach(button => {
+            button.addEventListener('click', () => {
+                console.log('Toggle button clicked, updating toggle state...');
+                // Use a small delay to let the togglebutton script finish its work
+                setTimeout(updateToggleButton, 10);
             });
-        }
+        });
     }
 
     const headerEnd = document.querySelector(".article-header-buttons");
@@ -160,11 +168,35 @@ document.addEventListener("DOMContentLoaded", () => {
         headerEnd.prepend(button);
     }
     
-    // Set up watchers for dropdown state changes
-    setupDropdownWatchers();
+    // Function to initialize watchers and state
+    function initializeToggleSystem() {
+        console.log('Initializing toggle system...');
+        setupDropdownWatchers();
+        updateToggleButton();
+    }
     
-    // Initial state check
-    updateToggleButton();
+    // Hook into the same system that togglebutton.js uses
+    const sphinxToggleRunWhenDOMLoaded = cb => {
+        if (document.readyState != 'loading') {
+            cb()
+        } else if (document.addEventListener) {
+            document.addEventListener('DOMContentLoaded', cb)
+        } else {
+            document.attachEvent('onreadystatechange', function() {
+                if (document.readyState == 'complete') cb()
+            })
+        }
+    }
+    
+    // Initialize our system after togglebutton.js has done its work
+    // We use a small delay to ensure togglebutton.js has finished
+    sphinxToggleRunWhenDOMLoaded(() => {
+        // Give togglebutton.js a moment to finish adding buttons
+        setTimeout(() => {
+            console.log('DOM loaded, initializing toggle synchronization...');
+            initializeToggleSystem();
+        }, 10);
+    });
 
     document.getElementById(toggleButtonId)?.addEventListener("click", () => {
         if (document.body.classList.contains(rootDropdownState)) {

--- a/src/sphinx_dropdown_toggle/static/dropdown_toggle.js
+++ b/src/sphinx_dropdown_toggle/static/dropdown_toggle.js
@@ -4,13 +4,15 @@ document.addEventListener("DOMContentLoaded", () => {
 
     // Check for dropdowns
     const article = document.querySelector('article.bd-article');
-    const dropdowns = article ? article.querySelectorAll('details.dropdown, details.sd-dropdown, details.toggle-details, div.dropdown, .sd-dropdown') : [];
+    if (!article) return; // Exit if no article found
+    
+    const dropdowns = article.querySelectorAll('details.dropdown, details.sd-dropdown, details.toggle-details, div.dropdown');
     if (dropdowns.length === 0) {
         return; // Exit if no dropdowns found
     }
 
     // Function to check current state of all dropdowns
-    function checkDropdownState(article) {
+    function checkDropdownState() {
         const details = article.querySelectorAll('details.dropdown, details.sd-dropdown, details.toggle-details');
         const toggleableDivs = article.querySelectorAll('div.dropdown button.toggle-button');
         
@@ -70,13 +72,13 @@ document.addEventListener("DOMContentLoaded", () => {
     // Function to set up observers for dropdown changes
     function setupDropdownWatchers() {
         // Watch for changes to details elements (includes Sphinx Design dropdowns)
-        const details = document.querySelectorAll('details.dropdown, details.sd-dropdown, details.toggle-details');
+        const details = article.querySelectorAll('details.dropdown, details.sd-dropdown, details.toggle-details');
         details.forEach(detail => {
             detail.addEventListener('toggle', updateToggleButton);
         });
         
-        // Watch for class changes on div dropdowns with toggle buttons
-        const toggleableDivs = Array.from(document.querySelectorAll('div.dropdown')).filter(div => div.querySelector('button.toggle-button'));
+        // Watch for class changes on div dropdowns with toggle buttons (scoped to article)
+        const toggleableDivs = Array.from(article.querySelectorAll('div.dropdown')).filter(div => div.querySelector('button.toggle-button'));
         
         if (toggleableDivs.length > 0) {
             const observer = new MutationObserver(() => updateToggleButton());
@@ -85,7 +87,7 @@ document.addEventListener("DOMContentLoaded", () => {
             });
         }
         
-        // Listen for clicks on interactive elements
+        // Listen for clicks on interactive elements globally (not scoped to article)
         const clickTargets = [
             ...document.querySelectorAll('.admonition-title'),
             ...document.querySelectorAll('button.toggle-button'),
@@ -155,17 +157,17 @@ document.addEventListener("DOMContentLoaded", () => {
         }
         
         // Open all details dropdowns
-        document.querySelectorAll('details.dropdown, details.sd-dropdown, details.toggle-details').forEach(detail => {
+        article.querySelectorAll('details.dropdown, details.sd-dropdown, details.toggle-details').forEach(detail => {
             if (!detail.open) {
                 detail.open = true;
             }
         });
         
         // Open all div dropdowns
-        document.querySelectorAll('div.dropdown').forEach(div => {
+        article.querySelectorAll('div.dropdown').forEach(div => {
             div.classList.remove('toggle-hidden');
         });
-        document.querySelectorAll('button.toggle-button').forEach(button => {
+        article.querySelectorAll('button.toggle-button').forEach(button => {
             button.classList.remove('toggle-button-hidden');
         });
     }
@@ -179,17 +181,17 @@ document.addEventListener("DOMContentLoaded", () => {
         }
         
         // Close all details dropdowns
-        document.querySelectorAll('details.dropdown, details.sd-dropdown, details.toggle-details').forEach(detail => {
+        article.querySelectorAll('details.dropdown, details.sd-dropdown, details.toggle-details').forEach(detail => {
             if (detail.open) {
                 detail.open = false;
             }
         });
         
         // Close all div dropdowns
-        document.querySelectorAll('div.dropdown').forEach(div => {
+        article.querySelectorAll('div.dropdown').forEach(div => {
             div.classList.add('toggle-hidden');
         });
-        document.querySelectorAll('button.toggle-button').forEach(button => {
+        article.querySelectorAll('button.toggle-button').forEach(button => {
             button.classList.add('toggle-button-hidden');
         });
     }

--- a/src/sphinx_dropdown_toggle/static/dropdown_toggle.js
+++ b/src/sphinx_dropdown_toggle/static/dropdown_toggle.js
@@ -43,34 +43,51 @@ document.addEventListener("DOMContentLoaded", () => {
         const { allOpen, allClosed } = checkDropdownState();
         const button = document.getElementById(toggleButtonId);
         
-        if (!button) return;
+        console.log('updateToggleButton called:', { allOpen, allClosed });
+        
+        if (!button) {
+            console.log('Toggle button not found');
+            return;
+        }
         
         if (allOpen) {
+            console.log('Setting to "close all" state');
             document.body.classList.add(rootDropdownState);
             button.innerHTML = '<i class="fa-solid fa-angles-up"></i>';
             button.title = "Close all dropdowns";
         } else if (allClosed) {
+            console.log('Setting to "open all" state');
             document.body.classList.remove(rootDropdownState);
             button.innerHTML = '<i class="fa-solid fa-angles-down"></i>';
             button.title = "Open all dropdowns";
+        } else {
+            console.log('Mixed state - keeping current button state');
         }
         // If some are open and some are closed, keep current state
     }
     
     // Function to set up observers for dropdown changes
     function setupDropdownWatchers() {
+        console.log('Setting up dropdown watchers...');
+        
         // Watch for changes to details elements
         const details = document.querySelectorAll('details.dropdown, details.sd-dropdown');
+        console.log('Found', details.length, 'details dropdowns');
         details.forEach(detail => {
-            detail.addEventListener('toggle', updateToggleButton);
+            detail.addEventListener('toggle', () => {
+                console.log('Details dropdown toggled:', detail.open);
+                updateToggleButton();
+            });
         });
         
         // Watch for class changes on div dropdowns using MutationObserver
         const divs = document.querySelectorAll('div.dropdown');
+        console.log('Found', divs.length, 'div dropdowns');
         if (divs.length > 0) {
             const observer = new MutationObserver((mutations) => {
                 mutations.forEach((mutation) => {
                     if (mutation.type === 'attributes' && mutation.attributeName === 'class') {
+                        console.log('Div dropdown class changed:', mutation.target.className);
                         updateToggleButton();
                     }
                 });
@@ -83,10 +100,12 @@ document.addEventListener("DOMContentLoaded", () => {
         
         // Also watch for toggle-button changes
         const buttons = document.querySelectorAll('button.toggle-button');
+        console.log('Found', buttons.length, 'toggle buttons');
         if (buttons.length > 0) {
             const buttonObserver = new MutationObserver((mutations) => {
                 mutations.forEach((mutation) => {
                     if (mutation.type === 'attributes' && mutation.attributeName === 'class') {
+                        console.log('Toggle button class changed:', mutation.target.className);
                         updateToggleButton();
                     }
                 });

--- a/src/sphinx_dropdown_toggle/static/dropdown_toggle.js
+++ b/src/sphinx_dropdown_toggle/static/dropdown_toggle.js
@@ -17,8 +17,11 @@ document.addEventListener("DOMContentLoaded", () => {
         let allOpen = true;
         let allClosed = true;
         
+        console.log('Checking dropdown state...');
+        
         // Check details elements
-        details.forEach(detail => {
+        details.forEach((detail, index) => {
+            console.log(`Details ${index}:`, detail.open);
             if (detail.open) {
                 allClosed = false;
             } else {
@@ -26,15 +29,39 @@ document.addEventListener("DOMContentLoaded", () => {
             }
         });
         
-        // Check div dropdowns (they're closed if they have toggle-hidden class)
-        divs.forEach(div => {
+        // Check div dropdowns - need to figure out how to detect if they're open
+        divs.forEach((div, index) => {
+            const classes = Array.from(div.classList);
+            console.log(`Div ${index} classes:`, classes);
+            
+            // Check if the div has toggle-hidden class (original logic)
             if (div.classList.contains('toggle-hidden')) {
                 allOpen = false;
+                console.log(`Div ${index} is closed (has toggle-hidden)`);
             } else {
-                allClosed = false;
+                // Also check for other potential "closed" indicators
+                const button = div.querySelector('button.toggle-button');
+                if (button) {
+                    const buttonClasses = Array.from(button.classList);
+                    console.log(`Div ${index} button classes:`, buttonClasses);
+                    
+                    // Check if button has toggle-button-hidden class
+                    if (button.classList.contains('toggle-button-hidden')) {
+                        allOpen = false;
+                        console.log(`Div ${index} is closed (button has toggle-button-hidden)`);
+                    } else {
+                        allClosed = false;
+                        console.log(`Div ${index} is open`);
+                    }
+                } else {
+                    // If no toggle button found, assume open
+                    allClosed = false;
+                    console.log(`Div ${index} has no toggle button, assuming open`);
+                }
             }
         });
         
+        console.log('State check result:', { allOpen, allClosed });
         return { allOpen, allClosed };
     }
     

--- a/src/sphinx_dropdown_toggle/static/dropdown_toggle.js
+++ b/src/sphinx_dropdown_toggle/static/dropdown_toggle.js
@@ -9,6 +9,95 @@ document.addEventListener("DOMContentLoaded", () => {
         return; // Exit if no dropdowns found
     }
 
+    // Function to check current state of all dropdowns
+    function checkDropdownState() {
+        const details = document.querySelectorAll('details.dropdown, details.sd-dropdown');
+        const divs = document.querySelectorAll('div.dropdown');
+        
+        let allOpen = true;
+        let allClosed = true;
+        
+        // Check details elements
+        details.forEach(detail => {
+            if (detail.open) {
+                allClosed = false;
+            } else {
+                allOpen = false;
+            }
+        });
+        
+        // Check div dropdowns (they're closed if they have toggle-hidden class)
+        divs.forEach(div => {
+            if (div.classList.contains('toggle-hidden')) {
+                allOpen = false;
+            } else {
+                allClosed = false;
+            }
+        });
+        
+        return { allOpen, allClosed };
+    }
+    
+    // Function to update toggle button based on dropdown state
+    function updateToggleButton() {
+        const { allOpen, allClosed } = checkDropdownState();
+        const button = document.getElementById(toggleButtonId);
+        
+        if (!button) return;
+        
+        if (allOpen) {
+            document.body.classList.add(rootDropdownState);
+            button.innerHTML = '<i class="fa-solid fa-angles-up"></i>';
+            button.title = "Close all dropdowns";
+        } else if (allClosed) {
+            document.body.classList.remove(rootDropdownState);
+            button.innerHTML = '<i class="fa-solid fa-angles-down"></i>';
+            button.title = "Open all dropdowns";
+        }
+        // If some are open and some are closed, keep current state
+    }
+    
+    // Function to set up observers for dropdown changes
+    function setupDropdownWatchers() {
+        // Watch for changes to details elements
+        const details = document.querySelectorAll('details.dropdown, details.sd-dropdown');
+        details.forEach(detail => {
+            detail.addEventListener('toggle', updateToggleButton);
+        });
+        
+        // Watch for class changes on div dropdowns using MutationObserver
+        const divs = document.querySelectorAll('div.dropdown');
+        if (divs.length > 0) {
+            const observer = new MutationObserver((mutations) => {
+                mutations.forEach((mutation) => {
+                    if (mutation.type === 'attributes' && mutation.attributeName === 'class') {
+                        updateToggleButton();
+                    }
+                });
+            });
+            
+            divs.forEach(div => {
+                observer.observe(div, { attributes: true, attributeFilter: ['class'] });
+            });
+        }
+        
+        // Also watch for toggle-button changes
+        const buttons = document.querySelectorAll('button.toggle-button');
+        if (buttons.length > 0) {
+            const buttonObserver = new MutationObserver((mutations) => {
+                mutations.forEach((mutation) => {
+                    if (mutation.type === 'attributes' && mutation.attributeName === 'class') {
+                        updateToggleButton();
+                    }
+                });
+            });
+            
+            buttons.forEach(button => {
+                buttonObserver.observe(button, { attributes: true, attributeFilter: ['class'] });
+            });
+        }
+    }
+
     const headerEnd = document.querySelector(".article-header-buttons");
     if (headerEnd) {
         const button = document.createElement("button");
@@ -19,6 +108,12 @@ document.addEventListener("DOMContentLoaded", () => {
 
         headerEnd.prepend(button);
     }
+    
+    // Set up watchers for dropdown state changes
+    setupDropdownWatchers();
+    
+    // Initial state check
+    updateToggleButton();
 
     document.getElementById(toggleButtonId)?.addEventListener("click", () => {
         if (document.body.classList.contains(rootDropdownState)) {


### PR DESCRIPTION
Done with some help of a friend

## Auto-update toggle button state when dropdowns change individually

Enhances the dropdown toggle button to automatically reflect the current state of all dropdowns on the page. The button now dynamically updates its icon and tooltip when users interact with individual dropdowns.

**Behavior:**
- **All closed**: Shows down arrows (⏬) with "Open all dropdowns" tooltip
- **All open**: Shows up arrows (⏫) with "Close all dropdowns" tooltip  
- **Mixed state**: Maintains current appearance until user clicks toggle

**Implementation:**
- Monitors `<details>` elements via `toggle` events
- Watches `div.dropdown` class changes with MutationObserver
- Listens for clicks on admonition titles and toggle buttons
- Compatible with all Sphinx dropdown types (admonitions, Sphinx Design, togglebutton.js)

**User Experience:**
Users can now see at a glance whether dropdowns are open/closed and the toggle button always shows the correct action. No more confusion about what the button will do when clicked.